### PR TITLE
2023-02-01 TypeScript

### DIFF
--- a/2023-02-01-ts/.eslintrc.json
+++ b/2023-02-01-ts/.eslintrc.json
@@ -6,5 +6,11 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
   ],
-  "root": true
+  "root": true,
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { "destructuredArrayIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ]
+  }
 }

--- a/2023-02-01-ts/README.md
+++ b/2023-02-01-ts/README.md
@@ -1,3 +1,9 @@
 # 2023-02-01 (TypeScript)
 
 Transformed the original `golden-master.ts` file to a function that returns a string instead of being a program that prints on the terminal so I could capture it and use **Jest**'s [`toMatchSnapshot`](https://jestjs.io/docs/snapshot-testing) for comparing the original behavior of the app (requirements are kind of fuzzy) to do [Approval testing](https://coding-is-like-cooking.info/tag/approval-testing/) with this golden master.
+
+Introduced an enum, `ItemKind` to distinguish different item kinds. Then an util function to get a variant of this enum from an item name. It was good to be able to test this separately from the rest of the logic.
+
+Started to tackle items logic kind by kind, starting from common items, which were the most simple. I followed a TDD approach to complement the approval testing so I could reason about the logic more easily and we have the business rules documented in code as well.
+
+Items are processed in an immutable way, although we could have modified them in spot.

--- a/2023-02-01-ts/README.md
+++ b/2023-02-01-ts/README.md
@@ -1,0 +1,3 @@
+# 2023-02-01 (TypeScript)
+
+Transformed the original `golden-master.ts` file to a function that returns a string instead of being a program that prints on the terminal so I could capture it and use **Jest**'s [`toMatchSnapshot`](https://jestjs.io/docs/snapshot-testing) for comparing the original behavior of the app (requirements are kind of fuzzy) to do [Approval testing](https://coding-is-like-cooking.info/tag/approval-testing/) with this golden master.

--- a/2023-02-01-ts/src/__snapshots__/gilded-rose.test.ts.snap
+++ b/2023-02-01-ts/src/__snapshots__/gilded-rose.test.ts.snap
@@ -15,3 +15,219 @@ Conjured Mana Cake 3 6
 
 "
 `;
+
+exports[`Gilded Rose golden master tests Matches the golden master after 2 days 1`] = `
+"-------- day 0 --------
+name, sellIn, quality
++5 Dexterity Vest 9 19
+Aged Brie 1 1
+Elixir of the Mongoose 4 6
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 14 21
+Backstage passes to a TAFKAL80ETC concert 9 50
+Backstage passes to a TAFKAL80ETC concert 4 50
+Conjured Mana Cake 2 5
+
+-------- day 1 --------
+name, sellIn, quality
++5 Dexterity Vest 8 18
+Aged Brie 0 2
+Elixir of the Mongoose 3 5
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 13 22
+Backstage passes to a TAFKAL80ETC concert 8 50
+Backstage passes to a TAFKAL80ETC concert 3 50
+Conjured Mana Cake 1 4
+
+"
+`;
+
+exports[`Gilded Rose golden master tests Matches the golden master after 5 days 1`] = `
+"-------- day 0 --------
+name, sellIn, quality
++5 Dexterity Vest 7 17
+Aged Brie -1 4
+Elixir of the Mongoose 2 4
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 12 23
+Backstage passes to a TAFKAL80ETC concert 7 50
+Backstage passes to a TAFKAL80ETC concert 2 50
+Conjured Mana Cake 0 3
+
+-------- day 1 --------
+name, sellIn, quality
++5 Dexterity Vest 6 16
+Aged Brie -2 6
+Elixir of the Mongoose 1 3
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 11 24
+Backstage passes to a TAFKAL80ETC concert 6 50
+Backstage passes to a TAFKAL80ETC concert 1 50
+Conjured Mana Cake -1 1
+
+-------- day 2 --------
+name, sellIn, quality
++5 Dexterity Vest 5 15
+Aged Brie -3 8
+Elixir of the Mongoose 0 2
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 10 25
+Backstage passes to a TAFKAL80ETC concert 5 50
+Backstage passes to a TAFKAL80ETC concert 0 50
+Conjured Mana Cake -2 0
+
+-------- day 3 --------
+name, sellIn, quality
++5 Dexterity Vest 4 14
+Aged Brie -4 10
+Elixir of the Mongoose -1 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 9 27
+Backstage passes to a TAFKAL80ETC concert 4 50
+Backstage passes to a TAFKAL80ETC concert -1 0
+Conjured Mana Cake -3 0
+
+-------- day 4 --------
+name, sellIn, quality
++5 Dexterity Vest 3 13
+Aged Brie -5 12
+Elixir of the Mongoose -2 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 8 29
+Backstage passes to a TAFKAL80ETC concert 3 50
+Backstage passes to a TAFKAL80ETC concert -2 0
+Conjured Mana Cake -4 0
+
+"
+`;
+
+exports[`Gilded Rose golden master tests Matches the golden master after 10 days 1`] = `
+"-------- day 0 --------
+name, sellIn, quality
++5 Dexterity Vest 2 12
+Aged Brie -6 14
+Elixir of the Mongoose -3 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 7 31
+Backstage passes to a TAFKAL80ETC concert 2 50
+Backstage passes to a TAFKAL80ETC concert -3 0
+Conjured Mana Cake -5 0
+
+-------- day 1 --------
+name, sellIn, quality
++5 Dexterity Vest 1 11
+Aged Brie -7 16
+Elixir of the Mongoose -4 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 6 33
+Backstage passes to a TAFKAL80ETC concert 1 50
+Backstage passes to a TAFKAL80ETC concert -4 0
+Conjured Mana Cake -6 0
+
+-------- day 2 --------
+name, sellIn, quality
++5 Dexterity Vest 0 10
+Aged Brie -8 18
+Elixir of the Mongoose -5 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 5 35
+Backstage passes to a TAFKAL80ETC concert 0 50
+Backstage passes to a TAFKAL80ETC concert -5 0
+Conjured Mana Cake -7 0
+
+-------- day 3 --------
+name, sellIn, quality
++5 Dexterity Vest -1 8
+Aged Brie -9 20
+Elixir of the Mongoose -6 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 4 38
+Backstage passes to a TAFKAL80ETC concert -1 0
+Backstage passes to a TAFKAL80ETC concert -6 0
+Conjured Mana Cake -8 0
+
+-------- day 4 --------
+name, sellIn, quality
++5 Dexterity Vest -2 6
+Aged Brie -10 22
+Elixir of the Mongoose -7 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 3 41
+Backstage passes to a TAFKAL80ETC concert -2 0
+Backstage passes to a TAFKAL80ETC concert -7 0
+Conjured Mana Cake -9 0
+
+-------- day 5 --------
+name, sellIn, quality
++5 Dexterity Vest -3 4
+Aged Brie -11 24
+Elixir of the Mongoose -8 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 2 44
+Backstage passes to a TAFKAL80ETC concert -3 0
+Backstage passes to a TAFKAL80ETC concert -8 0
+Conjured Mana Cake -10 0
+
+-------- day 6 --------
+name, sellIn, quality
++5 Dexterity Vest -4 2
+Aged Brie -12 26
+Elixir of the Mongoose -9 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 1 47
+Backstage passes to a TAFKAL80ETC concert -4 0
+Backstage passes to a TAFKAL80ETC concert -9 0
+Conjured Mana Cake -11 0
+
+-------- day 7 --------
+name, sellIn, quality
++5 Dexterity Vest -5 0
+Aged Brie -13 28
+Elixir of the Mongoose -10 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 0 50
+Backstage passes to a TAFKAL80ETC concert -5 0
+Backstage passes to a TAFKAL80ETC concert -10 0
+Conjured Mana Cake -12 0
+
+-------- day 8 --------
+name, sellIn, quality
++5 Dexterity Vest -6 0
+Aged Brie -14 30
+Elixir of the Mongoose -11 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert -1 0
+Backstage passes to a TAFKAL80ETC concert -6 0
+Backstage passes to a TAFKAL80ETC concert -11 0
+Conjured Mana Cake -13 0
+
+-------- day 9 --------
+name, sellIn, quality
++5 Dexterity Vest -7 0
+Aged Brie -15 32
+Elixir of the Mongoose -12 0
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert -2 0
+Backstage passes to a TAFKAL80ETC concert -7 0
+Backstage passes to a TAFKAL80ETC concert -12 0
+Conjured Mana Cake -14 0
+
+"
+`;

--- a/2023-02-01-ts/src/__snapshots__/gilded-rose.test.ts.snap
+++ b/2023-02-01-ts/src/__snapshots__/gilded-rose.test.ts.snap
@@ -19,6 +19,18 @@ Conjured Mana Cake 3 6
 exports[`Gilded Rose golden master tests Matches the golden master after 2 days 1`] = `
 "-------- day 0 --------
 name, sellIn, quality
++5 Dexterity Vest 10 20
+Aged Brie 2 0
+Elixir of the Mongoose 5 7
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 15 20
+Backstage passes to a TAFKAL80ETC concert 10 49
+Backstage passes to a TAFKAL80ETC concert 5 49
+Conjured Mana Cake 3 6
+
+-------- day 1 --------
+name, sellIn, quality
 +5 Dexterity Vest 9 19
 Aged Brie 1 1
 Elixir of the Mongoose 4 6
@@ -29,7 +41,35 @@ Backstage passes to a TAFKAL80ETC concert 9 50
 Backstage passes to a TAFKAL80ETC concert 4 50
 Conjured Mana Cake 2 5
 
+"
+`;
+
+exports[`Gilded Rose golden master tests Matches the golden master after 5 days 1`] = `
+"-------- day 0 --------
+name, sellIn, quality
++5 Dexterity Vest 10 20
+Aged Brie 2 0
+Elixir of the Mongoose 5 7
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 15 20
+Backstage passes to a TAFKAL80ETC concert 10 49
+Backstage passes to a TAFKAL80ETC concert 5 49
+Conjured Mana Cake 3 6
+
 -------- day 1 --------
+name, sellIn, quality
++5 Dexterity Vest 9 19
+Aged Brie 1 1
+Elixir of the Mongoose 4 6
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 14 21
+Backstage passes to a TAFKAL80ETC concert 9 50
+Backstage passes to a TAFKAL80ETC concert 4 50
+Conjured Mana Cake 2 5
+
+-------- day 2 --------
 name, sellIn, quality
 +5 Dexterity Vest 8 18
 Aged Brie 0 2
@@ -41,11 +81,7 @@ Backstage passes to a TAFKAL80ETC concert 8 50
 Backstage passes to a TAFKAL80ETC concert 3 50
 Conjured Mana Cake 1 4
 
-"
-`;
-
-exports[`Gilded Rose golden master tests Matches the golden master after 5 days 1`] = `
-"-------- day 0 --------
+-------- day 3 --------
 name, sellIn, quality
 +5 Dexterity Vest 7 17
 Aged Brie -1 4
@@ -57,7 +93,7 @@ Backstage passes to a TAFKAL80ETC concert 7 50
 Backstage passes to a TAFKAL80ETC concert 2 50
 Conjured Mana Cake 0 3
 
--------- day 1 --------
+-------- day 4 --------
 name, sellIn, quality
 +5 Dexterity Vest 6 16
 Aged Brie -2 6
@@ -69,7 +105,71 @@ Backstage passes to a TAFKAL80ETC concert 6 50
 Backstage passes to a TAFKAL80ETC concert 1 50
 Conjured Mana Cake -1 1
 
+"
+`;
+
+exports[`Gilded Rose golden master tests Matches the golden master after 10 days 1`] = `
+"-------- day 0 --------
+name, sellIn, quality
++5 Dexterity Vest 10 20
+Aged Brie 2 0
+Elixir of the Mongoose 5 7
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 15 20
+Backstage passes to a TAFKAL80ETC concert 10 49
+Backstage passes to a TAFKAL80ETC concert 5 49
+Conjured Mana Cake 3 6
+
+-------- day 1 --------
+name, sellIn, quality
++5 Dexterity Vest 9 19
+Aged Brie 1 1
+Elixir of the Mongoose 4 6
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 14 21
+Backstage passes to a TAFKAL80ETC concert 9 50
+Backstage passes to a TAFKAL80ETC concert 4 50
+Conjured Mana Cake 2 5
+
 -------- day 2 --------
+name, sellIn, quality
++5 Dexterity Vest 8 18
+Aged Brie 0 2
+Elixir of the Mongoose 3 5
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 13 22
+Backstage passes to a TAFKAL80ETC concert 8 50
+Backstage passes to a TAFKAL80ETC concert 3 50
+Conjured Mana Cake 1 4
+
+-------- day 3 --------
+name, sellIn, quality
++5 Dexterity Vest 7 17
+Aged Brie -1 4
+Elixir of the Mongoose 2 4
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 12 23
+Backstage passes to a TAFKAL80ETC concert 7 50
+Backstage passes to a TAFKAL80ETC concert 2 50
+Conjured Mana Cake 0 3
+
+-------- day 4 --------
+name, sellIn, quality
++5 Dexterity Vest 6 16
+Aged Brie -2 6
+Elixir of the Mongoose 1 3
+Sulfuras, Hand of Ragnaros 0 80
+Sulfuras, Hand of Ragnaros -1 80
+Backstage passes to a TAFKAL80ETC concert 11 24
+Backstage passes to a TAFKAL80ETC concert 6 50
+Backstage passes to a TAFKAL80ETC concert 1 50
+Conjured Mana Cake -1 1
+
+-------- day 5 --------
 name, sellIn, quality
 +5 Dexterity Vest 5 15
 Aged Brie -3 8
@@ -81,7 +181,7 @@ Backstage passes to a TAFKAL80ETC concert 5 50
 Backstage passes to a TAFKAL80ETC concert 0 50
 Conjured Mana Cake -2 0
 
--------- day 3 --------
+-------- day 6 --------
 name, sellIn, quality
 +5 Dexterity Vest 4 14
 Aged Brie -4 10
@@ -93,7 +193,7 @@ Backstage passes to a TAFKAL80ETC concert 4 50
 Backstage passes to a TAFKAL80ETC concert -1 0
 Conjured Mana Cake -3 0
 
--------- day 4 --------
+-------- day 7 --------
 name, sellIn, quality
 +5 Dexterity Vest 3 13
 Aged Brie -5 12
@@ -105,11 +205,7 @@ Backstage passes to a TAFKAL80ETC concert 3 50
 Backstage passes to a TAFKAL80ETC concert -2 0
 Conjured Mana Cake -4 0
 
-"
-`;
-
-exports[`Gilded Rose golden master tests Matches the golden master after 10 days 1`] = `
-"-------- day 0 --------
+-------- day 8 --------
 name, sellIn, quality
 +5 Dexterity Vest 2 12
 Aged Brie -6 14
@@ -121,7 +217,7 @@ Backstage passes to a TAFKAL80ETC concert 2 50
 Backstage passes to a TAFKAL80ETC concert -3 0
 Conjured Mana Cake -5 0
 
--------- day 1 --------
+-------- day 9 --------
 name, sellIn, quality
 +5 Dexterity Vest 1 11
 Aged Brie -7 16
@@ -132,102 +228,6 @@ Backstage passes to a TAFKAL80ETC concert 6 33
 Backstage passes to a TAFKAL80ETC concert 1 50
 Backstage passes to a TAFKAL80ETC concert -4 0
 Conjured Mana Cake -6 0
-
--------- day 2 --------
-name, sellIn, quality
-+5 Dexterity Vest 0 10
-Aged Brie -8 18
-Elixir of the Mongoose -5 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert 5 35
-Backstage passes to a TAFKAL80ETC concert 0 50
-Backstage passes to a TAFKAL80ETC concert -5 0
-Conjured Mana Cake -7 0
-
--------- day 3 --------
-name, sellIn, quality
-+5 Dexterity Vest -1 8
-Aged Brie -9 20
-Elixir of the Mongoose -6 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert 4 38
-Backstage passes to a TAFKAL80ETC concert -1 0
-Backstage passes to a TAFKAL80ETC concert -6 0
-Conjured Mana Cake -8 0
-
--------- day 4 --------
-name, sellIn, quality
-+5 Dexterity Vest -2 6
-Aged Brie -10 22
-Elixir of the Mongoose -7 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert 3 41
-Backstage passes to a TAFKAL80ETC concert -2 0
-Backstage passes to a TAFKAL80ETC concert -7 0
-Conjured Mana Cake -9 0
-
--------- day 5 --------
-name, sellIn, quality
-+5 Dexterity Vest -3 4
-Aged Brie -11 24
-Elixir of the Mongoose -8 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert 2 44
-Backstage passes to a TAFKAL80ETC concert -3 0
-Backstage passes to a TAFKAL80ETC concert -8 0
-Conjured Mana Cake -10 0
-
--------- day 6 --------
-name, sellIn, quality
-+5 Dexterity Vest -4 2
-Aged Brie -12 26
-Elixir of the Mongoose -9 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert 1 47
-Backstage passes to a TAFKAL80ETC concert -4 0
-Backstage passes to a TAFKAL80ETC concert -9 0
-Conjured Mana Cake -11 0
-
--------- day 7 --------
-name, sellIn, quality
-+5 Dexterity Vest -5 0
-Aged Brie -13 28
-Elixir of the Mongoose -10 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert 0 50
-Backstage passes to a TAFKAL80ETC concert -5 0
-Backstage passes to a TAFKAL80ETC concert -10 0
-Conjured Mana Cake -12 0
-
--------- day 8 --------
-name, sellIn, quality
-+5 Dexterity Vest -6 0
-Aged Brie -14 30
-Elixir of the Mongoose -11 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert -1 0
-Backstage passes to a TAFKAL80ETC concert -6 0
-Backstage passes to a TAFKAL80ETC concert -11 0
-Conjured Mana Cake -13 0
-
--------- day 9 --------
-name, sellIn, quality
-+5 Dexterity Vest -7 0
-Aged Brie -15 32
-Elixir of the Mongoose -12 0
-Sulfuras, Hand of Ragnaros 0 80
-Sulfuras, Hand of Ragnaros -1 80
-Backstage passes to a TAFKAL80ETC concert -2 0
-Backstage passes to a TAFKAL80ETC concert -7 0
-Backstage passes to a TAFKAL80ETC concert -12 0
-Conjured Mana Cake -14 0
 
 "
 `;

--- a/2023-02-01-ts/src/__snapshots__/gilded-rose.test.ts.snap
+++ b/2023-02-01-ts/src/__snapshots__/gilded-rose.test.ts.snap
@@ -39,7 +39,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 14 21
 Backstage passes to a TAFKAL80ETC concert 9 50
 Backstage passes to a TAFKAL80ETC concert 4 50
-Conjured Mana Cake 2 5
+Conjured Mana Cake 2 4
 
 "
 `;
@@ -67,7 +67,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 14 21
 Backstage passes to a TAFKAL80ETC concert 9 50
 Backstage passes to a TAFKAL80ETC concert 4 50
-Conjured Mana Cake 2 5
+Conjured Mana Cake 2 4
 
 -------- day 2 --------
 name, sellIn, quality
@@ -79,7 +79,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 13 22
 Backstage passes to a TAFKAL80ETC concert 8 50
 Backstage passes to a TAFKAL80ETC concert 3 50
-Conjured Mana Cake 1 4
+Conjured Mana Cake 1 2
 
 -------- day 3 --------
 name, sellIn, quality
@@ -91,7 +91,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 12 23
 Backstage passes to a TAFKAL80ETC concert 7 50
 Backstage passes to a TAFKAL80ETC concert 2 50
-Conjured Mana Cake 0 3
+Conjured Mana Cake 0 0
 
 -------- day 4 --------
 name, sellIn, quality
@@ -103,7 +103,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 11 24
 Backstage passes to a TAFKAL80ETC concert 6 50
 Backstage passes to a TAFKAL80ETC concert 1 50
-Conjured Mana Cake -1 1
+Conjured Mana Cake -1 0
 
 "
 `;
@@ -131,7 +131,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 14 21
 Backstage passes to a TAFKAL80ETC concert 9 50
 Backstage passes to a TAFKAL80ETC concert 4 50
-Conjured Mana Cake 2 5
+Conjured Mana Cake 2 4
 
 -------- day 2 --------
 name, sellIn, quality
@@ -143,7 +143,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 13 22
 Backstage passes to a TAFKAL80ETC concert 8 50
 Backstage passes to a TAFKAL80ETC concert 3 50
-Conjured Mana Cake 1 4
+Conjured Mana Cake 1 2
 
 -------- day 3 --------
 name, sellIn, quality
@@ -155,7 +155,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 12 23
 Backstage passes to a TAFKAL80ETC concert 7 50
 Backstage passes to a TAFKAL80ETC concert 2 50
-Conjured Mana Cake 0 3
+Conjured Mana Cake 0 0
 
 -------- day 4 --------
 name, sellIn, quality
@@ -167,7 +167,7 @@ Sulfuras, Hand of Ragnaros -1 80
 Backstage passes to a TAFKAL80ETC concert 11 24
 Backstage passes to a TAFKAL80ETC concert 6 50
 Backstage passes to a TAFKAL80ETC concert 1 50
-Conjured Mana Cake -1 1
+Conjured Mana Cake -1 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/2023-02-01-ts/src/gilded-rose.test.ts
+++ b/2023-02-01-ts/src/gilded-rose.test.ts
@@ -1,5 +1,5 @@
 import runGoldenMaster from "./test-data/golden-master";
-import { ItemKind, kindForItemName } from "./gilded-rose";
+import { ItemKind, kindForItemName, Item, GildedRose } from "./gilded-rose";
 
 describe("Gilded Rose golden master tests", () => {
   it("Matches the golden master after 1 day", () => {
@@ -40,5 +40,33 @@ describe("Item kinds", () => {
 
     expect(kind).toBe(ItemKind.Legendary);
     expect(altKind).toBe(ItemKind.Legendary);
+  });
+});
+
+const anyItem = () => {
+  return new Item("A sword", 5, 10);
+};
+
+const anyLegendaryItem = () => {
+  return new Item("Sulfuras", 0, 80);
+};
+
+describe("GildedRose", () => {
+  describe("Sell In values", () => {
+    it("Decreases in each update", () => {
+      const gildedRose = new GildedRose([anyItem()]);
+
+      const result = gildedRose.updateQuality();
+
+      expect(result[0].sellIn).toBe(4);
+    });
+
+    it("Remains constant for legendary items", () => {
+      const gildedRose = new GildedRose([anyLegendaryItem()]);
+
+      const result = gildedRose.updateQuality();
+
+      expect(result[0].sellIn).toBe(anyLegendaryItem().sellIn);
+    });
   });
 });

--- a/2023-02-01-ts/src/gilded-rose.test.ts
+++ b/2023-02-01-ts/src/gilded-rose.test.ts
@@ -29,9 +29,9 @@ describe("Item kinds", () => {
     expect(kind).toBe(ItemKind.AgedBrie);
   });
 
-  it("Returns `BackstagePasses` for concert passes", () => {
+  it("Returns `BackstagePass` for concert passes", () => {
     const kind = kindForItemName("Backstage passes to a TAFKAL80ETC concert");
-    expect(kind).toBe(ItemKind.BackstagePasses);
+    expect(kind).toBe(ItemKind.BackstagePass);
   });
 
   it("Returns `Legendary` for Sulfuras", () => {
@@ -57,6 +57,10 @@ const anyCommonItem = (sellIn: number, quality: number) => {
 
 const anyAgedBrie = (sellIn: number, quality: number) => {
   return new Item("Aged Brie", sellIn, quality);
+};
+
+const anyBackstagePass = (sellIn: number, quality: number) => {
+  return new Item("Backstage pass", sellIn, quality);
 };
 
 describe("GildedRose", () => {
@@ -104,6 +108,17 @@ describe("GildedRose", () => {
     });
   });
 
+  describe("Legendary item", () => {
+    it("Never has to be sold or decreases in quality", () => {
+      const gildedRose = new GildedRose([anyLegendaryItem()]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(anyLegendaryItem().quality);
+      expect(item.sellIn).toBe(anyLegendaryItem().sellIn);
+    });
+  });
+
   describe("Aged Brie", () => {
     it("Increases in quality the older it gets", () => {
       const gildedRose = new GildedRose([anyAgedBrie(1, 10)]);
@@ -123,6 +138,48 @@ describe("GildedRose", () => {
 
     it("Never gets updated above 50", () => {
       const gildedRose = new GildedRose([anyAgedBrie(1, 50)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(50);
+    });
+  });
+
+  describe("Backstage pass", () => {
+    it("Increases in quality by 1 when the concert approaches and 11+ days remain", () => {
+      const gildedRose = new GildedRose([anyBackstagePass(11, 20)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(21);
+    });
+
+    it("Increases in quality by 2 when 10 or less days remain", () => {
+      const gildedRose = new GildedRose([anyBackstagePass(10, 20)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(22);
+    });
+
+    it("Increases in quality by 3 when 5 or less days remain", () => {
+      const gildedRose = new GildedRose([anyBackstagePass(5, 20)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(23);
+    });
+
+    it("Drops to zero quality after the concert", () => {
+      const gildedRose = new GildedRose([anyBackstagePass(0, 20)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(0);
+    });
+
+    it("Never gets updated above 50 quality", () => {
+      const gildedRose = new GildedRose([anyBackstagePass(5, 49)]);
 
       const [item, ..._] = gildedRose.updateQuality();
 

--- a/2023-02-01-ts/src/gilded-rose.test.ts
+++ b/2023-02-01-ts/src/gilded-rose.test.ts
@@ -5,4 +5,19 @@ describe("Gilded Rose golden master tests", () => {
     const goldenMaster = runGoldenMaster(1);
     expect(goldenMaster).toMatchSnapshot();
   });
+
+  it("Matches the golden master after 2 days", () => {
+    const goldenMaster = runGoldenMaster(2);
+    expect(goldenMaster).toMatchSnapshot();
+  });
+
+  it("Matches the golden master after 5 days", () => {
+    const goldenMaster = runGoldenMaster(5);
+    expect(goldenMaster).toMatchSnapshot();
+  });
+
+  it("Matches the golden master after 10 days", () => {
+    const goldenMaster = runGoldenMaster(10);
+    expect(goldenMaster).toMatchSnapshot();
+  });
 });

--- a/2023-02-01-ts/src/gilded-rose.test.ts
+++ b/2023-02-01-ts/src/gilded-rose.test.ts
@@ -51,22 +51,82 @@ const anyLegendaryItem = () => {
   return new Item("Sulfuras", 0, 80);
 };
 
+const anyCommonItem = (sellIn: number, quality: number) => {
+  return new Item("A sword", sellIn, quality);
+};
+
+const anyAgedBrie = (sellIn: number, quality: number) => {
+  return new Item("Aged Brie", sellIn, quality);
+};
+
 describe("GildedRose", () => {
   describe("Sell In values", () => {
     it("Decreases in each update", () => {
       const gildedRose = new GildedRose([anyItem()]);
 
-      const result = gildedRose.updateQuality();
+      const [item, ..._] = gildedRose.updateQuality();
 
-      expect(result[0].sellIn).toBe(4);
+      expect(item.sellIn).toBe(anyItem().sellIn - 1);
     });
 
     it("Remains constant for legendary items", () => {
       const gildedRose = new GildedRose([anyLegendaryItem()]);
 
-      const result = gildedRose.updateQuality();
+      const [item, ..._] = gildedRose.updateQuality();
 
-      expect(result[0].sellIn).toBe(anyLegendaryItem().sellIn);
+      expect(item.sellIn).toBe(anyLegendaryItem().sellIn);
+    });
+  });
+
+  describe("Quality", () => {
+    it("Degrades for common items", () => {
+      const gildedRose = new GildedRose([anyCommonItem(1, 4)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(3);
+    });
+
+    it("Degrades twice as fast once the sell by date has passed", () => {
+      const gildedRose = new GildedRose([anyCommonItem(0, 4)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(2);
+    });
+
+    it("Never drops below zero", () => {
+      const gildedRose = new GildedRose([anyCommonItem(1, 0)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(0);
+    });
+  });
+
+  describe("Aged Brie", () => {
+    it("Increases in quality the older it gets", () => {
+      const gildedRose = new GildedRose([anyAgedBrie(1, 10)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(11);
+    });
+
+    it("Increases in quality twice as fast when the sell by date has passed", () => {
+      const gildedRose = new GildedRose([anyAgedBrie(0, 10)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(12);
+    });
+
+    it("Never gets updated above 50", () => {
+      const gildedRose = new GildedRose([anyAgedBrie(1, 50)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(50);
     });
   });
 });

--- a/2023-02-01-ts/src/gilded-rose.test.ts
+++ b/2023-02-01-ts/src/gilded-rose.test.ts
@@ -41,6 +41,16 @@ describe("Item kinds", () => {
     expect(kind).toBe(ItemKind.Legendary);
     expect(altKind).toBe(ItemKind.Legendary);
   });
+
+  it("Returns `Conjured` for a conjured item", () => {
+    const kind = kindForItemName("Conjured sword");
+    expect(kind).toBe(ItemKind.Conjured);
+  });
+
+  it("Returns `Common` for misc items", () => {
+    const kind = kindForItemName("Lorem ipsum");
+    expect(kind).toBe(ItemKind.Common);
+  });
 });
 
 const anyItem = () => {
@@ -61,6 +71,10 @@ const anyAgedBrie = (sellIn: number, quality: number) => {
 
 const anyBackstagePass = (sellIn: number, quality: number) => {
   return new Item("Backstage pass", sellIn, quality);
+};
+
+const anyConjuredItem = (sellIn: number, quality: number) => {
+  return new Item("Conjured gizmo", sellIn, quality);
 };
 
 describe("GildedRose", () => {
@@ -184,6 +198,32 @@ describe("GildedRose", () => {
       const [item, ..._] = gildedRose.updateQuality();
 
       expect(item.quality).toBe(50);
+    });
+  });
+
+  describe("Conjured item", () => {
+    it("Degrades twice as fast", () => {
+      const gildedRose = new GildedRose([anyConjuredItem(5, 10)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(8);
+    });
+
+    it("Degrades twice as fast when the sell by date has passed", () => {
+      const gildedRose = new GildedRose([anyConjuredItem(0, 10)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(6);
+    });
+
+    it("Never gets its quality drop below zero", () => {
+      const gildedRose = new GildedRose([anyConjuredItem(1, 0)]);
+
+      const [item, ..._] = gildedRose.updateQuality();
+
+      expect(item.quality).toBe(0);
     });
   });
 });

--- a/2023-02-01-ts/src/gilded-rose.test.ts
+++ b/2023-02-01-ts/src/gilded-rose.test.ts
@@ -1,4 +1,5 @@
 import runGoldenMaster from "./test-data/golden-master";
+import { ItemKind, kindForItemName } from "./gilded-rose";
 
 describe("Gilded Rose golden master tests", () => {
   it("Matches the golden master after 1 day", () => {
@@ -19,5 +20,25 @@ describe("Gilded Rose golden master tests", () => {
   it("Matches the golden master after 10 days", () => {
     const goldenMaster = runGoldenMaster(10);
     expect(goldenMaster).toMatchSnapshot();
+  });
+});
+
+describe("Item kinds", () => {
+  it("Returns `AgedBrie` for aged brie", () => {
+    const kind = kindForItemName("Aged Brie");
+    expect(kind).toBe(ItemKind.AgedBrie);
+  });
+
+  it("Returns `BackstagePasses` for concert passes", () => {
+    const kind = kindForItemName("Backstage passes to a TAFKAL80ETC concert");
+    expect(kind).toBe(ItemKind.BackstagePasses);
+  });
+
+  it("Returns `Legendary` for Sulfuras", () => {
+    const kind = kindForItemName("Sulfuras, Hand of Ragnaros");
+    const altKind = kindForItemName("Sulfuras");
+
+    expect(kind).toBe(ItemKind.Legendary);
+    expect(altKind).toBe(ItemKind.Legendary);
   });
 });

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -29,6 +29,7 @@ export enum ItemKind {
   BackstagePass = "Backstage passes",
   Legendary = "Legendary",
   Common = "Common",
+  Conjured = "Conjured",
 }
 
 export function kindForItemName(name: string): ItemKind {
@@ -44,6 +45,10 @@ export function kindForItemName(name: string): ItemKind {
     return ItemKind.Legendary;
   }
 
+  if (/^conjured(\s.+)?/i.test(name)) {
+    return ItemKind.Conjured;
+  }
+
   return ItemKind.Common;
 }
 
@@ -57,6 +62,8 @@ export function updateQualityForItem(item: Item): Item {
       return updateLegendaryItem(item);
     case ItemKind.BackstagePass:
       return updateBackstagePassItem(item);
+    case ItemKind.Conjured:
+      return updateConjuredItem(item);
     default:
       return updateCommonItem(item);
   }
@@ -106,6 +113,14 @@ function updateBackstagePassItem(item: Item): Item {
     Math.max(0, item.quality + qualityDelta),
     GildedRose.MAX_QUALITY
   );
+
+  return new Item(item.name, sellIn, quality);
+}
+
+function updateConjuredItem(item: Item): Item {
+  const sellIn = item.sellIn - 1;
+  const qualityDelta = sellIn >= 0 ? -2 : -4;
+  const quality = Math.max(0, item.quality + qualityDelta);
 
   return new Item(item.name, sellIn, quality);
 }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -22,6 +22,10 @@ export class GildedRose {
     this.items = this.items.map(updateQualityForItem);
     return this.items;
   }
+
+  static clampQuality(quality: number): number {
+    return Math.min(Math.max(0, quality), this.MAX_QUALITY);
+  }
 }
 
 export enum ItemKind {
@@ -82,10 +86,7 @@ function updateAgedBrieItem(item: Item): Item {
   const sellIn = item.sellIn - 1;
 
   const qualityDelta = sellIn >= 0 ? 1 : 2;
-  const quality = Math.min(
-    Math.max(0, item.quality + qualityDelta),
-    GildedRose.MAX_QUALITY
-  );
+  const quality = GildedRose.clampQuality(item.quality + qualityDelta);
 
   return new Item(item.name, sellIn, quality);
 }
@@ -109,10 +110,7 @@ function updateBackstagePassItem(item: Item): Item {
   })(item.sellIn);
 
   const sellIn = item.sellIn - 1;
-  const quality = Math.min(
-    Math.max(0, item.quality + qualityDelta),
-    GildedRose.MAX_QUALITY
-  );
+  const quality = GildedRose.clampQuality(item.quality + qualityDelta);
 
   return new Item(item.name, sellIn, quality);
 }
@@ -120,7 +118,7 @@ function updateBackstagePassItem(item: Item): Item {
 function updateConjuredItem(item: Item): Item {
   const sellIn = item.sellIn - 1;
   const qualityDelta = sellIn >= 0 ? -2 : -4;
-  const quality = Math.max(0, item.quality + qualityDelta);
+  const quality = GildedRose.clampQuality(item.quality + qualityDelta);
 
   return new Item(item.name, sellIn, quality);
 }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -46,7 +46,7 @@ export function kindForItemName(name: string): ItemKind {
   return ItemKind.Common;
 }
 
-function updateQualityForItem(item: Item): Item {
+export function updateQualityForItem(item: Item): Item {
   let quality = item.quality;
   let sellIn = item.sellIn;
 

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -50,19 +50,18 @@ function updateQualityForItem(item: Item): Item {
   let quality = item.quality;
   let sellIn = item.sellIn;
 
-  if (
-    item.name != "Aged Brie" &&
-    item.name != "Backstage passes to a TAFKAL80ETC concert"
-  ) {
+  const kind = kindForItemName(item.name);
+
+  if (kind !== ItemKind.AgedBrie && kind !== ItemKind.BackstagePasses) {
     if (quality > 0) {
-      if (item.name != "Sulfuras, Hand of Ragnaros") {
+      if (kind != ItemKind.Legendary) {
         quality = quality - 1;
       }
     }
   } else {
     if (quality < 50) {
       quality = quality + 1;
-      if (item.name == "Backstage passes to a TAFKAL80ETC concert") {
+      if (kind === ItemKind.BackstagePasses) {
         if (sellIn < 11) {
           if (quality < 50) {
             quality = quality + 1;
@@ -77,15 +76,15 @@ function updateQualityForItem(item: Item): Item {
     }
   }
 
-  if (item.name != "Sulfuras, Hand of Ragnaros") {
+  if (kind !== ItemKind.Legendary) {
     sellIn = sellIn - 1;
   }
 
   if (sellIn < 0) {
-    if (item.name != "Aged Brie") {
-      if (item.name != "Backstage passes to a TAFKAL80ETC concert") {
+    if (kind !== ItemKind.AgedBrie) {
+      if (kind !== ItemKind.BackstagePasses) {
         if (quality > 0) {
-          if (item.name != "Sulfuras, Hand of Ragnaros") {
+          if (kind !== ItemKind.Legendary) {
             quality = quality - 1;
           }
         }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -11,6 +11,7 @@ export class Item {
 }
 
 export class GildedRose {
+  static MAX_QUALITY = 50;
   items: Array<Item>;
 
   constructor(items = [] as Array<Item>) {
@@ -47,12 +48,18 @@ export function kindForItemName(name: string): ItemKind {
 }
 
 export function updateQualityForItem(item: Item): Item {
+  const kind = kindForItemName(item.name);
+
+  if (kind === ItemKind.Common) {
+    return updateCommonItem(item);
+  } else if (kind === ItemKind.AgedBrie) {
+    return updateAgedBrie(item);
+  }
+
   let quality = item.quality;
   let sellIn = item.sellIn;
 
-  const kind = kindForItemName(item.name);
-
-  if (kind !== ItemKind.AgedBrie && kind !== ItemKind.BackstagePasses) {
+  if (kind !== ItemKind.BackstagePasses) {
     if (quality > 0) {
       if (kind != ItemKind.Legendary) {
         quality = quality - 1;
@@ -79,20 +86,14 @@ export function updateQualityForItem(item: Item): Item {
   sellIn = updateSellInForKind(sellIn, kind);
 
   if (sellIn < 0) {
-    if (kind !== ItemKind.AgedBrie) {
-      if (kind !== ItemKind.BackstagePasses) {
-        if (quality > 0) {
-          if (kind !== ItemKind.Legendary) {
-            quality = quality - 1;
-          }
+    if (kind !== ItemKind.BackstagePasses) {
+      if (quality > 0) {
+        if (kind !== ItemKind.Legendary) {
+          quality = quality - 1;
         }
-      } else {
-        quality = quality - quality;
       }
     } else {
-      if (quality < 50) {
-        quality = quality + 1;
-      }
+      quality = quality - quality;
     }
   }
 
@@ -101,4 +102,25 @@ export function updateQualityForItem(item: Item): Item {
 
 function updateSellInForKind(currentSellIn: number, kind: ItemKind): number {
   return kind !== ItemKind.Legendary ? currentSellIn - 1 : currentSellIn;
+}
+
+function updateCommonItem(item: Item): Item {
+  const sellIn = item.sellIn - 1;
+
+  const qualityDelta = sellIn >= 0 ? -1 : -2;
+  const quality = Math.max(0, item.quality + qualityDelta);
+
+  return new Item(item.name, sellIn, quality);
+}
+
+function updateAgedBrie(item: Item): Item {
+  const sellIn = item.sellIn - 1;
+
+  const qualityDelta = sellIn >= 0 ? 1 : 2;
+  const quality = Math.min(
+    Math.max(0, item.quality + qualityDelta),
+    GildedRose.MAX_QUALITY
+  );
+
+  return new Item(item.name, sellIn, quality);
 }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -76,9 +76,7 @@ function updateQualityForItem(item: Item): Item {
     }
   }
 
-  if (kind !== ItemKind.Legendary) {
-    sellIn = sellIn - 1;
-  }
+  sellIn = updateSellInForKind(sellIn, kind);
 
   if (sellIn < 0) {
     if (kind !== ItemKind.AgedBrie) {
@@ -99,4 +97,8 @@ function updateQualityForItem(item: Item): Item {
   }
 
   return new Item(item.name, sellIn, quality);
+}
+
+function updateSellInForKind(currentSellIn: number, kind: ItemKind): number {
+  return kind !== ItemKind.Legendary ? currentSellIn - 1 : currentSellIn;
 }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -23,6 +23,29 @@ export class GildedRose {
   }
 }
 
+export enum ItemKind {
+  AgedBrie = "Aged brie",
+  BackstagePasses = "Backstage passes",
+  Legendary = "Legendary",
+  Common = "Common",
+}
+
+export function kindForItemName(name: string): ItemKind {
+  if (/^aged brie$/i.test(name)) {
+    return ItemKind.AgedBrie;
+  }
+
+  if (/^backstage passes/i.test(name)) {
+    return ItemKind.BackstagePasses;
+  }
+
+  if (/^sulfuras([,\s]?.+|$)/i.test(name)) {
+    return ItemKind.Legendary;
+  }
+
+  return ItemKind.Common;
+}
+
 function updateQualityForItem(item: Item): Item {
   let quality = item.quality;
   let sellIn = item.sellIn;

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -18,56 +18,63 @@ export class GildedRose {
   }
 
   updateQuality() {
-    this.items.forEach(updateQualityForItem);
+    this.items = this.items.map(updateQualityForItem);
     return this.items;
   }
 }
 
-function updateQualityForItem(item: Item) {
+function updateQualityForItem(item: Item): Item {
+  let quality = item.quality;
+  let sellIn = item.sellIn;
+
   if (
     item.name != "Aged Brie" &&
     item.name != "Backstage passes to a TAFKAL80ETC concert"
   ) {
-    if (item.quality > 0) {
+    if (quality > 0) {
       if (item.name != "Sulfuras, Hand of Ragnaros") {
-        item.quality = item.quality - 1;
+        quality = quality - 1;
       }
     }
   } else {
-    if (item.quality < 50) {
-      item.quality = item.quality + 1;
+    if (quality < 50) {
+      quality = quality + 1;
       if (item.name == "Backstage passes to a TAFKAL80ETC concert") {
-        if (item.sellIn < 11) {
-          if (item.quality < 50) {
-            item.quality = item.quality + 1;
+        if (sellIn < 11) {
+          if (quality < 50) {
+            quality = quality + 1;
           }
         }
-        if (item.sellIn < 6) {
-          if (item.quality < 50) {
-            item.quality = item.quality + 1;
+        if (sellIn < 6) {
+          if (quality < 50) {
+            quality = quality + 1;
           }
         }
       }
     }
   }
+
   if (item.name != "Sulfuras, Hand of Ragnaros") {
-    item.sellIn = item.sellIn - 1;
+    sellIn = sellIn - 1;
   }
-  if (item.sellIn < 0) {
+
+  if (sellIn < 0) {
     if (item.name != "Aged Brie") {
       if (item.name != "Backstage passes to a TAFKAL80ETC concert") {
-        if (item.quality > 0) {
+        if (quality > 0) {
           if (item.name != "Sulfuras, Hand of Ragnaros") {
-            item.quality = item.quality - 1;
+            quality = quality - 1;
           }
         }
       } else {
-        item.quality = item.quality - item.quality;
+        quality = quality - quality;
       }
     } else {
-      if (item.quality < 50) {
-        item.quality = item.quality + 1;
+      if (quality < 50) {
+        quality = quality + 1;
       }
     }
   }
+
+  return new Item(item.name, sellIn, quality);
 }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -18,60 +18,56 @@ export class GildedRose {
   }
 
   updateQuality() {
-    for (let i = 0; i < this.items.length; i++) {
-      if (
-        this.items[i].name != "Aged Brie" &&
-        this.items[i].name != "Backstage passes to a TAFKAL80ETC concert"
-      ) {
-        if (this.items[i].quality > 0) {
-          if (this.items[i].name != "Sulfuras, Hand of Ragnaros") {
-            this.items[i].quality = this.items[i].quality - 1;
+    this.items.forEach(updateQualityForItem);
+    return this.items;
+  }
+}
+
+function updateQualityForItem(item: Item) {
+  if (
+    item.name != "Aged Brie" &&
+    item.name != "Backstage passes to a TAFKAL80ETC concert"
+  ) {
+    if (item.quality > 0) {
+      if (item.name != "Sulfuras, Hand of Ragnaros") {
+        item.quality = item.quality - 1;
+      }
+    }
+  } else {
+    if (item.quality < 50) {
+      item.quality = item.quality + 1;
+      if (item.name == "Backstage passes to a TAFKAL80ETC concert") {
+        if (item.sellIn < 11) {
+          if (item.quality < 50) {
+            item.quality = item.quality + 1;
           }
         }
-      } else {
-        if (this.items[i].quality < 50) {
-          this.items[i].quality = this.items[i].quality + 1;
-          if (
-            this.items[i].name == "Backstage passes to a TAFKAL80ETC concert"
-          ) {
-            if (this.items[i].sellIn < 11) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-            if (this.items[i].sellIn < 6) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1;
-              }
-            }
-          }
-        }
-      }
-      if (this.items[i].name != "Sulfuras, Hand of Ragnaros") {
-        this.items[i].sellIn = this.items[i].sellIn - 1;
-      }
-      if (this.items[i].sellIn < 0) {
-        if (this.items[i].name != "Aged Brie") {
-          if (
-            this.items[i].name != "Backstage passes to a TAFKAL80ETC concert"
-          ) {
-            if (this.items[i].quality > 0) {
-              if (this.items[i].name != "Sulfuras, Hand of Ragnaros") {
-                this.items[i].quality = this.items[i].quality - 1;
-              }
-            }
-          } else {
-            this.items[i].quality =
-              this.items[i].quality - this.items[i].quality;
-          }
-        } else {
-          if (this.items[i].quality < 50) {
-            this.items[i].quality = this.items[i].quality + 1;
+        if (item.sellIn < 6) {
+          if (item.quality < 50) {
+            item.quality = item.quality + 1;
           }
         }
       }
     }
-
-    return this.items;
+  }
+  if (item.name != "Sulfuras, Hand of Ragnaros") {
+    item.sellIn = item.sellIn - 1;
+  }
+  if (item.sellIn < 0) {
+    if (item.name != "Aged Brie") {
+      if (item.name != "Backstage passes to a TAFKAL80ETC concert") {
+        if (item.quality > 0) {
+          if (item.name != "Sulfuras, Hand of Ragnaros") {
+            item.quality = item.quality - 1;
+          }
+        }
+      } else {
+        item.quality = item.quality - item.quality;
+      }
+    } else {
+      if (item.quality < 50) {
+        item.quality = item.quality + 1;
+      }
+    }
   }
 }

--- a/2023-02-01-ts/src/gilded-rose.ts
+++ b/2023-02-01-ts/src/gilded-rose.ts
@@ -50,62 +50,16 @@ export function kindForItemName(name: string): ItemKind {
 export function updateQualityForItem(item: Item): Item {
   const kind = kindForItemName(item.name);
 
-  if (kind === ItemKind.Common) {
-    return updateCommonItem(item);
-  } else if (kind === ItemKind.AgedBrie) {
-    return updateAgedBrieItem(item);
-  } else if (kind === ItemKind.Legendary) {
-    return updateLegendaryItem(item);
-  } else if (kind === ItemKind.BackstagePass) {
-    return updateBackstagePassItem(item);
+  switch (kind) {
+    case ItemKind.AgedBrie:
+      return updateAgedBrieItem(item);
+    case ItemKind.Legendary:
+      return updateLegendaryItem(item);
+    case ItemKind.BackstagePass:
+      return updateBackstagePassItem(item);
+    default:
+      return updateCommonItem(item);
   }
-
-  let quality = item.quality;
-  let sellIn = item.sellIn;
-
-  if (kind !== ItemKind.BackstagePass) {
-    if (quality > 0) {
-      if (kind != ItemKind.Legendary) {
-        quality = quality - 1;
-      }
-    }
-  } else {
-    if (quality < 50) {
-      quality = quality + 1;
-      if (kind === ItemKind.BackstagePass) {
-        if (sellIn < 11) {
-          if (quality < 50) {
-            quality = quality + 1;
-          }
-        }
-        if (sellIn < 6) {
-          if (quality < 50) {
-            quality = quality + 1;
-          }
-        }
-      }
-    }
-  }
-
-  sellIn = updateSellInForKind(sellIn, kind);
-
-  if (sellIn < 0) {
-    if (kind !== ItemKind.BackstagePass) {
-      if (quality > 0) {
-        if (kind !== ItemKind.Legendary) {
-          quality = quality - 1;
-        }
-      }
-    } else {
-      quality = quality - quality;
-    }
-  }
-
-  return new Item(item.name, sellIn, quality);
-}
-
-function updateSellInForKind(currentSellIn: number, kind: ItemKind): number {
-  return kind !== ItemKind.Legendary ? currentSellIn - 1 : currentSellIn;
 }
 
 function updateCommonItem(item: Item): Item {

--- a/2023-02-01-ts/src/test-data/golden-master.ts
+++ b/2023-02-01-ts/src/test-data/golden-master.ts
@@ -1,27 +1,27 @@
 import { Item, GildedRose } from "../gilded-rose";
 
-const items = [
-  new Item("+5 Dexterity Vest", 10, 20),
-  new Item("Aged Brie", 2, 0),
-  new Item("Elixir of the Mongoose", 5, 7),
-  new Item("Sulfuras, Hand of Ragnaros", 0, 80),
-  new Item("Sulfuras, Hand of Ragnaros", -1, 80),
-  new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
-  new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
-  new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
-  // this conjured item does not work properly yet
-  new Item("Conjured Mana Cake", 3, 6),
-];
-
-const gildedRose = new GildedRose(items);
-
 export default function runGildedRose(days: number): string {
+  const items = [
+    new Item("+5 Dexterity Vest", 10, 20),
+    new Item("Aged Brie", 2, 0),
+    new Item("Elixir of the Mongoose", 5, 7),
+    new Item("Sulfuras, Hand of Ragnaros", 0, 80),
+    new Item("Sulfuras, Hand of Ragnaros", -1, 80),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+    new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
+    // this conjured item does not work properly yet
+    new Item("Conjured Mana Cake", 3, 6),
+  ];
+
+  const gildedRose = new GildedRose(items);
+
   let output = "";
 
   for (let i = 0; i < days; i++) {
     output += `-------- day ${i} --------\n`;
     output += `name, sellIn, quality\n`;
-    items.forEach((element) => {
+    gildedRose.items.forEach((element) => {
       output += `${element.name} ${element.sellIn} ${element.quality}\n`;
     });
     output += "\n";

--- a/2023-02-01-ts/src/test-data/golden-master.ts
+++ b/2023-02-01-ts/src/test-data/golden-master.ts
@@ -10,7 +10,6 @@ export default function runGildedRose(days: number): string {
     new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
     new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
     new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
-    // this conjured item does not work properly yet
     new Item("Conjured Mana Cake", 3, 6),
   ];
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@ Original: https://github.com/emilybache/GildedRose-Refactoring-Kata
 
 ## Instructions
 
+Hi and welcome to team Gilded Rose. As you know, we are a small inn with a prime location in a prominent city ran by a friendly innkeeper named Allison. We also buy and sell only the finest goods. Unfortunately, our goods are constantly degrading in quality as they approach their sell by date. We have a system in place that updates our inventory for us. It was developed by a no-nonsense type named Leeroy, who has moved on to new adventures. Your task is to add the new feature to our system so that we can begin selling a new category of items. First, an introduction to our system:
+
+- All items have a `sellIn` value which denotes the number of days we have to sell the item.
+- All items have a `quality` value which denotes how valuable the item is.
+- At the end of each day our system lowers both values for every item.
+
+Pretty simple, right? Well this is where it gets interesting:
+
+- Once the sell by date has passed, `quality` degrades twice as fast.
+- The `quality` of an item is never negative.
+- `"Aged Brie"` actually increases in `quality` the older it gets.
+- The `quality` of an item is never more than `50`.
+- `"Sulfuras"`, being a legendary item, never has to be sold or decreases in `quality`.
+- `"Backstage passes"`, like aged brie, increases in `quality` as its `sellIn` value approaches; `quality` increases by `2` when there are 10 days or less and by `3` when there are 5 days or less, but `quality` drops to `0` after the concert.
+
+**Your task**:
+
+We have recently signed a supplier of conjured items. This requires an update to our system:
+
+- `"Conjured"` items degrade in `quality` twice as fast as normal items.
+
+**Rules**:
+
+Feel free to make any changes to the `updateQuality` method and add any new code as long as everything still works correctly. However, **do not alter the `Item` class** or `items` property, as those belong to the goblin in the corner who will insta-rage and one-shot you as he doesn’t believe in shared code ownership (you can make the `updateQuality` method and `items` property static if you like, we’ll cover for you).
+
+Just for clarification, an item can never have its `quality` increase above `50`, however `"Sulfuras"` is a legendary item and as such its `quality` is `80` and it never alters.
+
 ## Log
 
 ### [2023-02-01 (TypeScript)](./2023-02-01-ts/README.md)

--- a/README.md
+++ b/README.md
@@ -39,4 +39,5 @@ Just for clarification, an item can never have its `quality` increase above `50`
 
 - Used Jest's `toMatchSnapshot()` for **approval testing**.
 - Added an enum to identify items types (`AgedBrie`, `BackstagePass`, `Common`, etc.).
-- Processed each item kind update separately.
+- Processed each item kind update separately, with functions.
+- Items are treated as immutable (although the original `Item` class allows for modifications).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # kata-gilded-rose
 
-My take(s) at the Gilded Rose kata. 
+My take(s) at the Gilded Rose kata.
 
 Original: https://github.com/emilybache/GildedRose-Refactoring-Kata
+
+## Instructions
+
+## Log
+
+### [2023-02-01 (TypeScript)](./2023-02-01-ts/README.md)
+
+- Used Jest's `toMatchSnapshot()` for **approval testing**.
+-

--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ Just for clarification, an item can never have its `quality` increase above `50`
 ### [2023-02-01 (TypeScript)](./2023-02-01-ts/README.md)
 
 - Used Jest's `toMatchSnapshot()` for **approval testing**.
--
+- Added an enum to identify items types (`AgedBrie`, `BackstagePass`, `Common`, etc.).
+- Processed each item kind update separately.


### PR DESCRIPTION
- add more snapshot tests
- update readme files
- add instructions
- extract processing single item into separate function
- fix snapshots so tests are idempotent
- make the single processing item function not to modify the item its passed, but to return a copy
- implement item kinds
- use kinds instead of hardcoded strings
- extract sellIn update to separate function
- add tests for sellIn updates
- implement updating for common items + aged brie
- implement backstage passes
- update each item kind separately
- implement conjured and update snapshots
- fix linter errors
- dry clamping quality
- add more info to the readme
